### PR TITLE
Remove real aws key values

### DIFF
--- a/compose/bridge-net-compose.yml
+++ b/compose/bridge-net-compose.yml
@@ -31,5 +31,5 @@ services:
     volumes:
       - type: bind
         source: ${HOST_DIR}
-        target: ${CONT_DIR}
+        target: /var/log/purpleteam/outcomes
 

--- a/compose/host-net-compose.yml
+++ b/compose/host-net-compose.yml
@@ -23,5 +23,5 @@ services:
     volumes:
       - type: bind
         source: ${HOST_DIR}
-        target: ${CONT_DIR}
+        target: /var/log/purpleteam/outcomes
 

--- a/compose/orchestrator-testers-compose.yml
+++ b/compose/orchestrator-testers-compose.yml
@@ -30,8 +30,8 @@ services:
         LOCAL_GROUP_ID: ${APP_SCANNER_GROUP_ID}
     environment:
       - NODE_ENV=local
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_ACCESS_KEY_ID=arbitrary_aws_access_key_id
+      - AWS_SECRET_ACCESS_KEY=arbitrary_aws_secret_access_key
     # Following values are analogous to their Dockerfile counterparts:
     # -i : Keep STDIN open even if not attached
     # -t : Allocate a pseudo-tty
@@ -41,7 +41,7 @@ services:
     volumes:
      - type: bind
        source: ${HOST_DIR}
-       target: ${CONT_DIR}
+       target: /var/log/purpleteam/outcomes
 
   orchestrator:
     depends_on:
@@ -69,5 +69,5 @@ services:
     volumes:
      - type: bind
        source: ${HOST_DIR}
-       target: ${CONT_DIR}
+       target: /var/log/purpleteam/outcomes
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dc-up-orchestrator": "npm run dc-orchestrator up",
     "// AWS: Setting Credentials in Node.js": "https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html",
     "// AWS Credentials into a Docker Container without Hardcoding It": "https://cameroneckelberry.co/words/getting-aws-credentials-into-a-docker-container-without-hardcoding-it",
-    "dc-orchestrator-testers": "APP_SCANNER_GROUP_ID=$(id -g) APP_SCANNER_USER_ID=$(id -u) ORCHESTRATOR_GROUP_ID=$(id -g) ORCHESTRATOR_USER_ID=$(id -u) AWS_ACCESS_KEY_ID=$(aws --profile default configure get aws_access_key_id) AWS_SECRET_ACCESS_KEY=$(aws --profile default configure get aws_secret_access_key) docker-compose -f ./compose/orchestrator-testers-compose.yml",
+    "dc-orchestrator-testers": "APP_SCANNER_GROUP_ID=$(id -g) APP_SCANNER_USER_ID=$(id -u) ORCHESTRATOR_GROUP_ID=$(id -g) ORCHESTRATOR_USER_ID=$(id -u) docker-compose -f ./compose/orchestrator-testers-compose.yml",
     "// orchestrator debugging": "following commands",
     "dc-build-debug-orchestrator": "npm run dc-orchestrator-testers -- -f ./compose/orchestrator-testers-compose.debug_orchestrator.yml build",
     "dc-up-debug-orchestrator": "npm run dc-orchestrator-testers -- -f ./compose/orchestrator-testers-compose.debug_orchestrator.yml up",


### PR DESCRIPTION
The aws keys that were being passed in are only required to exist
not actually be right. The aws sdk loads these when it loads,
but they're not actually used in the local environment.

Also removed the CONT_DIR env var,
as there is no need for it to be configurable.

### Checklist

* [x] I have read the contributing guidelines
* [x] I have read the documentation
* [x] I have included a descriptive Pull Request title
* [x] I have included a Pull Request description of my changes
* [x] I have included tests where/when required (see contributing guidelines)
* [ ] I have included documentation modifications/additions where/when required (see contributing guidelines)  
  Not yet

Addresses issue 5 in private IaC repo